### PR TITLE
FEATURE #3335 single event request and subscription support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.bundle/
+/.idea/
 /.yardoc
 /_yardoc/
 /coverage/

--- a/README.md
+++ b/README.md
@@ -100,6 +100,15 @@ irb(main):005:0> client.events[:results]
 irb(main):005:0> client.events[:next_link]
 ```
 
+**Get my event by id**
+
+```ruby
+irb(main):005:0> client.event('identifier')
+irb(main):005:0> client.event('identifier')[:results]
+```
+
+Results will return an array even if it is a single result.  
+
 **Get my mails by access token**
 
 ```ruby
@@ -170,6 +179,37 @@ irb(main):005:0> response.access_token
 irb(main):005:0> response.refresh_token
 => "0.ARgA7EiQdLv1qECnFqPfrznKsT9ERYaGfG9Ki5WzQtEllj8YAJk.AgABAAEAAAD--DLA3VO7QrddgJg7WevrAgDs_wQA9P-Q1ODlBsrdZi-5s2mfLtEsavBgiEhGcz1KEf26fMrGFU3LM_og5l6wjSAtQ83XHLuje0_KYGol26_LGV_uH0F1MwCFR1N3ctwg4_...."
 ```
+
+**Create Subscription: it will create a webhook for Office365**
+
+```ruby
+args = {
+  changeType: "updated,deleted",
+  notificationUrl: "https://hello-world.com/office365/notifications",
+  lifecycleNotificationUrl: "https://hello-world.com/office365/lifecycle_notifications",
+  resource: "/me/{type}",
+  expirationDateTime: "2024-08-07T12:00:00.0000000Z",
+  clientState: "SecretClientState"
+}
+
+irb(main):005:0> subscription = client.create_subscription(args)
+```
+
+will return the subscription object `Office365::Models::Subscription`
+
+**Renew Subscription**
+
+```ruby
+args = {
+  identifier: "subscription-identifier",
+  expirationDateTime: "2024-08-08T12:00:00.0000000Z"
+}
+
+irb(main):005:0> subscription = client.renew_subscription(args)
+```
+
+will return the subscription object `Office365::Models::Subscription`
+
 
 ## Development
 

--- a/lib/office365/models.rb
+++ b/lib/office365/models.rb
@@ -12,5 +12,6 @@ module Office365
     autoload :Contact,            "office365/models/contact"
     autoload :AccessToken,        "office365/models/access_token"
     autoload :Event,              "office365/models/event"
+    autoload :Subscription,       "office365/models/subscription"
   end
 end

--- a/lib/office365/models/subscription.rb
+++ b/lib/office365/models/subscription.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Office365
+  module Models
+    class Subscription < Base
+    end
+  end
+end

--- a/lib/office365/rest/api.rb
+++ b/lib/office365/rest/api.rb
@@ -5,6 +5,7 @@ require_relative "./mailbox"
 require_relative "./calendar"
 require_relative "./contact"
 require_relative "./event"
+require_relative "./subscription"
 require_relative "./token"
 
 module Office365
@@ -16,6 +17,7 @@ module Office365
       include Office365::REST::Event
       include Office365::REST::Contact
       include Office365::REST::Token
+      include Office365::REST::Subscription
     end
   end
 end

--- a/lib/office365/rest/concerns/base.rb
+++ b/lib/office365/rest/concerns/base.rb
@@ -13,7 +13,7 @@ module Office365
           response = get_request(args: args)
 
           # If we are getting a single item by id, return the result as an array
-          return { results: [kclass.new(response)].flatten } if identifier.present?
+          return { results: [kclass.new(response)].flatten } unless identifier.nil?
 
           {
             results: response["value"].map { |v| kclass.new(v) },

--- a/lib/office365/rest/concerns/base.rb
+++ b/lib/office365/rest/concerns/base.rb
@@ -8,7 +8,12 @@ module Office365
 
         def wrap_results(args)
           kclass    = args.delete(:kclass)
+          get_by_id = args.delete(:get_by_id)
+
           response  = get_request(args: args)
+
+          # If we are getting a single item by id, return the result as an array
+          return { results: [response].flatten } if get_by_id
 
           {
             results: response["value"].map { |v| kclass.new(v) },

--- a/lib/office365/rest/concerns/base.rb
+++ b/lib/office365/rest/concerns/base.rb
@@ -7,13 +7,13 @@ module Office365
         private
 
         def wrap_results(args)
-          kclass    = args.delete(:kclass)
-          get_by_id = args.delete(:get_by_id)
+          kclass     = args.delete(:kclass)
+          identifier = args.delete(:identifier)
 
-          response  = get_request(args: args)
+          response = get_request(args: args)
 
           # If we are getting a single item by id, return the result as an array
-          return { results: [kclass.new(response)].flatten } if get_by_id
+          return { results: [kclass.new(response)].flatten } if identifier.present?
 
           {
             results: response["value"].map { |v| kclass.new(v) },

--- a/lib/office365/rest/concerns/base.rb
+++ b/lib/office365/rest/concerns/base.rb
@@ -13,7 +13,7 @@ module Office365
           response  = get_request(args: args)
 
           # If we are getting a single item by id, return the result as an array
-          return { results: [response].flatten } if get_by_id
+          return { results: [kclass.new(response)].flatten } if get_by_id
 
           {
             results: response["value"].map { |v| kclass.new(v) },

--- a/lib/office365/rest/event.rb
+++ b/lib/office365/rest/event.rb
@@ -12,6 +12,12 @@ module Office365
       def events(args = {})
         wrap_results(args.merge(kclass: Models::Event, base_uri: "/me/events"))
       end
+
+      def event(identifier)
+        raise ArgumentError, "Identifier must be provided" if identifier.nil? || identifier.empty?
+
+        wrap_results(kclass: Models::Event, base_uri: "/me/events/#{identifier}", get_by_id: true)
+      end
     end
   end
 end

--- a/lib/office365/rest/event.rb
+++ b/lib/office365/rest/event.rb
@@ -6,7 +6,7 @@ module Office365
   module REST
     module Event
       include Concerns::Base
-      BASE_URI = "/me/events".freeze
+      BASE_URI = "/me/events"
 
       # params: args => { next_link: (nil / next_page_url) }
       # response { results: [], next_link: '...' }

--- a/lib/office365/rest/event.rb
+++ b/lib/office365/rest/event.rb
@@ -6,17 +6,18 @@ module Office365
   module REST
     module Event
       include Concerns::Base
+      BASE_URI = "/me/events".freeze
 
       # params: args => { next_link: (nil / next_page_url) }
       # response { results: [], next_link: '...' }
       def events(args = {})
-        wrap_results(args.merge(kclass: Models::Event, base_uri: "/me/events"))
+        wrap_results(args.merge(kclass: Models::Event, base_uri: BASE_URI))
       end
 
       def event(identifier)
         raise ArgumentError, "Identifier must be provided" if identifier.nil? || identifier.empty?
 
-        wrap_results(kclass: Models::Event, base_uri: "/me/events/#{identifier}", get_by_id: true)
+        wrap_results(kclass: Models::Event, base_uri: [BASE_URI, identifier].join("/"), identifier: identifier)
       end
     end
   end

--- a/lib/office365/rest/request.rb
+++ b/lib/office365/rest/request.rb
@@ -29,12 +29,26 @@ module Office365
 
       def post(uri, args)
         req_url = URI(uri.start_with?("https") ? uri : (Office365::API_HOST + uri))
+        json_header = args.delete(:json_header)
 
-        response = Faraday.new(url: [req_url.scheme, "://", req_url.hostname].join, headers: post_headers) do |faraday|
+        response = Faraday.new(url: [req_url.scheme, "://", req_url.hostname].join, headers: json_header ? headers : post_headers) do |faraday|
           faraday.adapter Faraday.default_adapter
           faraday.response :json
           faraday.response :logger, ::Logger.new($stdout), bodies: true if dev_developement?
-        end.post(req_url.request_uri, args.ms_hash_to_query)
+        end.post(req_url.request_uri, json_header ? args.to_json : args.ms_hash_to_query)
+
+        parse_respond(response)
+      end
+
+      def patch(uri, args)
+        req_url = URI(uri.start_with?("https") ? uri : (Office365::API_HOST + uri))
+        json_header = args.delete(:json_header)
+
+        response = Faraday.new(url: [req_url.scheme, "://", req_url.hostname].join, headers: json_header ? headers : post_headers) do |faraday|
+          faraday.adapter Faraday.default_adapter
+          faraday.response :json
+          faraday.response :logger, ::Logger.new($stdout), bodies: true if dev_developement?
+        end.patch(req_url.request_uri, json_header ? args.to_json : args.ms_hash_to_query)
 
         parse_respond(response)
       end
@@ -44,7 +58,7 @@ module Office365
       def parse_respond(response)
         resp_body = response.body
 
-        return resp_body if response.status == 200
+        return resp_body if [200, 201].include?(response.status)
 
         raise InvaliRequestError, resp_body["error_description"] if response.status == 400
         raise InvalidAuthenticationTokenError, resp_body.dig("error", "message") if response.status == 401

--- a/lib/office365/rest/subscription.rb
+++ b/lib/office365/rest/subscription.rb
@@ -4,6 +4,12 @@ module Office365
   module REST
     module Subscription
       def create_subscription(args = {})
+        raise ArgumentError, "Missing changeType" if args[:changeType].nil?
+        raise ArgumentError, "Missing notificationUrl" if args[:notificationUrl].nil?
+        raise ArgumentError, "Missing resource" if args[:resource].nil?
+        raise ArgumentError, "Missing expirationDateTime" if args[:expirationDateTime].nil?
+        raise ArgumentError, "Missing clientState" if args[:clientState].nil?
+
         Models::Subscription.new(
           Request.new(access_token, debug: debug).post("/v1.0/subscriptions", { json_header: true }.merge(args))
         )

--- a/lib/office365/rest/subscription.rb
+++ b/lib/office365/rest/subscription.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Office365
+  module REST
+    module Subscription
+      def create_subscription(args = {})
+        Models::Subscription.new(
+          Request.new(access_token, debug: debug).post("/v1.0/subscriptions", { json_header: true }.merge(args))
+        )
+      end
+
+      def renew_subscription(args = {})
+        raise ArgumentError, "Missing subscription identifier" if args[:identifier].nil?
+
+        identifier = args.delete(:identifier)
+
+        Models::Subscription.new(
+          Request.new(access_token, debug: debug).patch("/v1.0/subscriptions/#{identifier}", { json_header: true }.merge(args))
+        )
+      end
+    end
+  end
+end

--- a/spec/fixtures/vcr_cassettes/office365_create_subscription.yml
+++ b/spec/fixtures/vcr_cassettes/office365_create_subscription.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://graph.microsoft.com/v1.0/subscriptions
+    body:
+      encoding: UTF-8
+      string: '{"changeType":"deleted,updated","notificationUrl":"https://hello-world.com/office365/notifications","lifecycleNotificationUrl":"https://hello-world.com/office365/lifecycle_notifications","resource":"/me/events","expirationDateTime":"2024-08-07T12:00:00.0000000Z","clientState":"SecretClientState"}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.10.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Cache-Control:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Location:
+      - https://subscriptionstore.windows.net/1.0/NA/subscriptions('56de97c4-a108-417d-9ac3-368a026a03d2')
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 8a0242a0-58d3-4bfe-89be-8b146c96143f
+      Client-Request-Id:
+      - 8a0242a0-58d3-4bfe-89be-8b146c96143f
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Japan East","Slice":"E","Ring":"5","ScaleUnit":"000","RoleInstance":"TY1PEPF0000604B"}}'
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Wed, 07 Aug 2024 07:43:58 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#subscriptions/$entity","id":"subscription-identifier","resource":"/me/events","applicationId":"hello-world-app","changeType":"updated,deleted","clientState":"SecretClientState","notificationUrl":"https://hello-world.com/office365/notifications","notificationQueryOptions":null,"lifecycleNotificationUrl":"https://hello-world.com/office365/lifecycle_notifications","expirationDateTime":"2024-08-07T12:00:00Z","creatorId":"6de11dbd-7bf6-44e9-9c95-80de80a07ce1","includeResourceData":null,"latestSupportedTlsVersion":"v1_2","encryptionCertificate":null,"encryptionCertificateId":null,"notificationUrlAppId":null}'
+  recorded_at: Wed, 07 Aug 2024 07:43:58 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/office365_event_by_id.yml
+++ b/spec/fixtures/vcr_cassettes/office365_event_by_id.yml
@@ -1,0 +1,87 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://graph.microsoft.com/v1.0/me/events/identifier
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.10.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; odata.metadata=minimal; odata.streaming=true; IEEE754Compatible=false;
+        charset=utf-8
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - de4f3049-6405-460a-a55f-ed4bdea241b8
+      Client-Request-Id:
+      - de4f3049-6405-460a-a55f-ed4bdea241b8
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Japan East","Slice":"E","Ring":"5","ScaleUnit":"000","RoleInstance":"TY1PEPF0000824F"}}'
+      Date:
+      - Wed, 07 Aug 2024 07:22:31 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#users(''hello-world'')/events/$entity","@odata.etag":"W/\"Ac4KMsV340S4R0LwqVXF0QABrVpntg==\"","id":"identifier","createdDateTime":"2024-08-07T04:11:02.9716249Z","lastModifiedDateTime":"2024-08-07T04:13:22.1273089Z","changeKey":"Ac4KMsV340S4R0LwqVXF0QABrVpntg==","categories":[],"transactionId":"6decf4fd-c54d-c637-046a-988b36495045","originalStartTimeZone":"China
+        Standard Time","originalEndTimeZone":"China Standard Time","iCalUId":"040000008200E00074C5B7101A82E008000000008B353AD17FE8DA0100000000000000001000000097A327F1F55F8545A9AACF1240707768","uid":"040000008200E00074C5B7101A82E008000000008B353AD17FE8DA0100000000000000001000000097A327F1F55F8545A9AACF1240707768","reminderMinutesBeforeStart":15,"isReminderOn":true,"hasAttachments":false,"subject":"event
+        test","bodyPreview":"Test for Webhook\r\n\r\n________________________________________________________________________________\r\nMicrosoft
+        Teams Need help?\r\nJoin the meeting now\r\nMeeting ID: 220 721 647 395\r\nPasscode:
+        xrNBkb\r\n________________________________\r\nFor organizers: Meetin","importance":"normal","sensitivity":"normal","isAllDay":false,"isCancelled":false,"isOrganizer":true,"responseRequested":true,"seriesMasterId":null,"showAs":"busy","type":"singleInstance","webLink":"https://outlook.office365.com/owa/?itemid=identifier%3D&exvsurl=1&path=/calendar/item","onlineMeetingUrl":null,"isOnlineMeeting":true,"onlineMeetingProvider":"teamsForBusiness","allowNewTimeProposals":true,"occurrenceId":null,"isDraft":false,"hideAttendees":false,"responseStatus":{"response":"organizer","time":"0001-01-01T00:00:00Z"},"body":{"contentType":"html","content":"<html>\r\n<head>\r\n<meta
+        http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">\r\n</head>\r\n<body>\r\n<div
+        style=\"font-family:Aptos,Aptos_EmbeddedFont,Aptos_MSFontService,Calibri,Helvetica,sans-serif;
+        font-size:12pt; color:rgb(0,0,0)\">\r\nTest for Webhook</div>\r\n<br>\r\n<div
+        style=\"max-width:520px\">\r\n<div style=\"white-space:nowrap; margin-bottom:24px;
+        font-family:&quot;Segoe UI&quot;,&quot;Helvetica Neue&quot;,Helvetica,Arial,sans-serif;
+        color:rgb(36,36,36)\">\r\n________________________________________________________________________________</div>\r\n<div
+        style=\"margin-bottom:12px; font-family:&quot;Segoe UI&quot;,&quot;Helvetica
+        Neue&quot;,Helvetica,Arial,sans-serif\">\r\n<span style=\"font-size:24px;
+        color:rgb(36,36,36); font-weight:700\">Microsoft Teams</span><span style=\"color:rgb(36,36,36)\">\r\n</span><span
+        style=\"font-size:14px; color:rgb(91,95,199)\"><u><a href=\"https://aka.ms/JoinTeamsMeeting?omkt=en-US\"
+        id=\"x_meet_invite_block.action.help\" class=\"x_me-email-link OWAAutoLink\"
+        style=\"color:rgb(91,95,199)\">Need help?</a></u></span></div>\r\n<div style=\"margin-bottom:6px;
+        font-family:&quot;Segoe UI&quot;,&quot;Helvetica Neue&quot;,Helvetica,Arial,sans-serif;
+        font-size:20px; color:rgb(91,95,199)\">\r\n<span style=\"font-weight:600\"><u><a
+        href=\"https://teams.microsoft.com/l/meetup-join/19%3ameeting_Hello_world%40thread.v2/0?context=%7b%22Tid%22%3a%22749048ec-f5bb-40a8-a716-a3dfaf39cab1%22%2c%22Oid%22%3a%22hello-world%22%7d\"
+        id=\"x_meet_invite_block.action.join_link\" class=\"x_me-email-headline OWAAutoLink\"
+        title=\"Meeting join link\" style=\"color:rgb(91,95,199)\">Join\r\n the meeting
+        now</a></u></span></div>\r\n<div style=\"margin-bottom:6px; font-family:&quot;Segoe
+        UI&quot;,&quot;Helvetica Neue&quot;,Helvetica,Arial,sans-serif\">\r\n<span
+        style=\"font-size:14px; color:rgb(97,97,97)\">Meeting ID: </span><span style=\"font-size:14px;
+        color:rgb(36,36,36)\">220 721 647 395</span><span style=\"color:rgb(36,36,36)\">\r\n</span></div>\r\n<div
+        style=\"margin-bottom:24px; font-family:&quot;Segoe UI&quot;,&quot;Helvetica
+        Neue&quot;,Helvetica,Arial,sans-serif\">\r\n<span style=\"font-size:14px;
+        color:rgb(97,97,97)\">Passcode: </span><span style=\"font-size:14px; color:rgb(36,36,36)\">xrNBkb</span><span
+        style=\"color:rgb(36,36,36)\">\r\n</span></div>\r\n<div style=\"margin-bottom:24px;
+        max-width:532px\">\r\n<hr style=\"background-color:rgb(209,209,209); height:1px\">\r\n</div>\r\n<div
+        style=\"font-family:&quot;Segoe UI&quot;,&quot;Helvetica Neue&quot;,Helvetica,Arial,sans-serif;
+        font-size:14px\">\r\n<span style=\"color:rgb(97,97,97)\">For organizers: </span><span
+        style=\"color:rgb(91,95,199)\"><u><a href=\"https://teams.microsoft.com/meetingOptions/?organizerId=hello-world&amp;tenantId=749048ec-f5bb-40a8-a716-a3dfaf39cab1&amp;threadId=19_meeting_ZGIxZTcxYjMtMDg0Ni00ZjRiLTg5NTYtOWNjZWRmOWJhOTFk@thread.v2&amp;messageId=0&amp;language=en-US\"
+        id=\"x_meet_invite_block.action.organizer_meet_options\" class=\"x_me-email-link
+        OWAAutoLink\" style=\"color:rgb(91,95,199)\">Meeting\r\n options</a></u></span></div>\r\n<div
+        style=\"margin-top:24px; margin-bottom:6px\"></div>\r\n<div style=\"margin-bottom:24px\"></div>\r\n<div
+        style=\"white-space:nowrap; margin-bottom:24px; font-family:&quot;Segoe UI&quot;,&quot;Helvetica
+        Neue&quot;,Helvetica,Arial,sans-serif; color:rgb(36,36,36)\">\r\n________________________________________________________________________________</div>\r\n</div>\r\n</body>\r\n</html>\r\n"},"start":{"dateTime":"2024-08-28T02:00:00.0000000","timeZone":"UTC"},"end":{"dateTime":"2024-08-28T02:30:00.0000000","timeZone":"UTC"},"location":{"displayName":"Microsoft
+        Teams Meeting","locationType":"default","uniqueId":"Microsoft Teams Meeting","uniqueIdType":"private"},"locations":[{"displayName":"Microsoft
+        Teams Meeting","locationType":"default","uniqueId":"Microsoft Teams Meeting","uniqueIdType":"private"}],"recurrence":null,"attendees":[{"type":"required","status":{"response":"none","time":"0001-01-01T00:00:00Z"},"emailAddress":{"name":"hello2@world.com","address":"hello2@world.com"}}],"organizer":{"emailAddress":{"name":"Hello
+        World","address":"hello@world.com"}},"onlineMeeting":{"joinUrl":"https://teams.microsoft.com/l/meetup-join/19%3ameeting_Hello_world%40thread.v2/0?context=%7b%22Tid%22%3a%22749048ec-f5bb-40a8-a716-a3dfaf39cab1%22%2c%22Oid%22%3a%22hello-world%22%7d"},"calendar@odata.associationLink":"https://graph.microsoft.com/v1.0/users(''hello-world'')/calendars(''hello-calendar'')/$ref","calendar@odata.navigationLink":"https://graph.microsoft.com/v1.0/users(''hello-world'')/calendars(''hello-calendar'')"}'
+  recorded_at: Wed, 07 Aug 2024 07:22:31 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/office365_renew_subscription.yml
+++ b/spec/fixtures/vcr_cassettes/office365_renew_subscription.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: patch
+    uri: https://graph.microsoft.com/v1.0/subscriptions/subscription-identifier
+    body:
+      encoding: UTF-8
+      string: '{"expirationDateTime":"2024-08-08T12:00:00.0000000Z"}'
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Faraday v1.10.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age=31536000
+      Request-Id:
+      - 00ff5106-5be8-44a6-8771-234579aaa157
+      Client-Request-Id:
+      - 00ff5106-5be8-44a6-8771-234579aaa157
+      X-Ms-Ags-Diagnostic:
+      - '{"ServerInfo":{"DataCenter":"Japan East","Slice":"E","Ring":"5","ScaleUnit":"000","RoleInstance":"TY1PEPF00006060"}}'
+      Odata-Version:
+      - '4.0'
+      Date:
+      - Wed, 07 Aug 2024 07:55:49 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#subscriptions/$entity","id":"subscription-identifier","resource":"/me/events","applicationId":"hello-world-app","changeType":"updated,deleted","clientState":"SecretClientState","notificationUrl":"https://sonar.inbound.staging.ekohe.com/office365/notifications","notificationQueryOptions":null,"lifecycleNotificationUrl":"https://sonar.inbound.staging.ekohe.com/office365/lifecycle_notifications","expirationDateTime":"2024-08-08T12:00:00Z","creatorId":"6de11dbd-7bf6-44e9-9c95-80de80a07ce1","includeResourceData":null,"latestSupportedTlsVersion":"v1_2","encryptionCertificate":null,"encryptionCertificateId":null,"notificationUrlAppId":null}'
+  recorded_at: Wed, 07 Aug 2024 07:55:50 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
Hello @encoreshao 

this PR contains support to:
- GET single event -> `/me/events/{id}`
- POST subscription -> `/v1.0/subscriptions` (create webhook for O365)
- PATCH subscription -> `/v1.0/subscriptions/{identifier}` (update webhook expiresDate)

please have a look and let me know if any concerns

~~PS: Drafting it, I am making some tests in local development.~~