### PR TITLE
Ensure next_link will manage correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Office365 Library Changelog
 
+## [0.2.1] - (2024-12-11)
+
+- FIX events: Manage correctly next_link
+
 ## [0.2.0] - (2024-11-14)
 
 - New feature on events: Allows users to get events by expected dates

--- a/lib/office365/rest/event.rb
+++ b/lib/office365/rest/event.rb
@@ -16,10 +16,12 @@ module Office365
       def events(args = {})
         if args[:startdatetime] && args[:enddatetime]
           wrap_results(
-            kclass: Models::Event,
-            base_uri: CALENDARVIEW_URL,
-            startdatetime: args[:startdatetime],
-            enddatetime: args[:enddatetime]
+            args.merge(
+              kclass: Models::Event,
+              base_uri: CALENDARVIEW_URL,
+              startdatetime: args[:startdatetime],
+              enddatetime: args[:enddatetime]
+            )
           )
         else
           wrap_results(args.merge(kclass: Models::Event, base_uri: BASE_URI))

--- a/lib/office365/version.rb
+++ b/lib/office365/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Office365
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
Hello @encoreshao 

when I was pulling events from O365, I realized that we are pulling the same data every time. It seems like if there is a  next_link, we will have an infinite loop that will stop the job after the token expired.

here is the fix to it.